### PR TITLE
Fix setHttpAsyncClient typo

### DIFF
--- a/NotificationHubs/src/com/windowsazure/messaging/HttpClientManager.java
+++ b/NotificationHubs/src/com/windowsazure/messaging/HttpClientManager.java
@@ -22,7 +22,7 @@ public class HttpClientManager {
 		
 	public static void setHttpAsyncClient(CloseableHttpAsyncClient httpAsyncClient) {
 		synchronized(HttpClientManager.class) {
-			if(httpAsyncClient == null) {
+			if(HttpClientManager.httpAsyncClient == null) {
 				HttpClientManager.httpAsyncClient = httpAsyncClient;
 			}
 			else{


### PR DESCRIPTION
Fix issue with setHttpAsyncClient - in the null comparison it references
the method parameter instead of the static class param.
