### PR TITLE
Fixing errors when initializing the NotificationHub obj

### DIFF
--- a/NotificationHubs/src/com/windowsazure/messaging/GcmCredential.java
+++ b/NotificationHubs/src/com/windowsazure/messaging/GcmCredential.java
@@ -20,6 +20,10 @@ public final class GcmCredential extends PnsCredential {
 		return googleApiKey;
 	}
 
+   	public void setgoogleApiKey(String googleApiKey) {
+        	this.googleApiKey = googleApiKey; // fix for reflection that's calling 'setgoogleApiKey' instead of 'setGoogleApiKey'.
+    	}
+
 	public void setGoogleApiKey(String googleApiKey) {
 		this.googleApiKey = googleApiKey;
 	}	

--- a/NotificationHubs/src/com/windowsazure/messaging/WindowsCredential.java
+++ b/NotificationHubs/src/com/windowsazure/messaging/WindowsCredential.java
@@ -34,6 +34,11 @@ public final class WindowsCredential extends PnsCredential {
 		this.secretKey = secretKey;
 	}	
 	
+    	public void setWindowsLiveEndpoint(String propertyValue) throws Exception {
+        	// fix for reflection that's calling 'setWindowsLiveEndpoint' of null.
+        	// unused function
+    	}
+
 	@Override
 	public List<SimpleEntry<String, String>> getProperties() {
 		ArrayList<SimpleEntry<String, String>> result = new ArrayList<SimpleEntry<String, String>>();


### PR DESCRIPTION
To reproduce the error, run the following lines of code:

```

    private static final String SENDERID = "<Enter your senderID>";
    private static final String HUBNAME = "<enter your hub id>";
    private static final String CONNECTION_STRING = "Endpoint=sb://bi<enter your endpoint>";

    private static final NamespaceManager NAMESPACE = new NamespaceManager(CONNECTION_STRING);

    private static PeriodicPushNotification INSTANCE;

    private static NotificationHub hub;
    private static NotificationHubDescription hubDesc;

    public static PeriodicPushNotification getInstance() {
        if (INSTANCE == null) {
            INSTANCE = new PeriodicPushNotification();

            try {
                **hub = new NotificationHub(CONNECTION_STRING, HUBNAME); // Error occurs here.** 
                hubDesc = NAMESPACE.getNotificationHub(HUBNAME);
            } catch (NotificationHubsException exp) {
                exp.printStackTrace();

                throw new RuntimeException("Error initializing notification hub."); // rethrow... cant do much about this crap
            }
        }
        return INSTANCE;
    }
```