### PR TITLE
Environment variable to select the strategy of httpclient creation 

### DIFF
--- a/NotificationHubs/src/com/windowsazure/messaging/HttpClientManager.java
+++ b/NotificationHubs/src/com/windowsazure/messaging/HttpClientManager.java
@@ -3,14 +3,28 @@ package com.windowsazure.messaging;
 import org.apache.http.impl.nio.client.CloseableHttpAsyncClient;
 import org.apache.http.impl.nio.client.HttpAsyncClients;
 
+
 public class HttpClientManager {
+
+	/** Name of system property to activate httpAsyncClient create with system properties */
+	public static final String SYSTEM_HTTP_CLIENT_CREATE = "http_client_type";
+
 	private static CloseableHttpAsyncClient httpAsyncClient;
-	
+
 	public static CloseableHttpAsyncClient getHttpAsyncClient() {
 		if(httpAsyncClient == null) {
 			synchronized(HttpClientManager.class) {
 				if(httpAsyncClient == null) {
+					/* Create http client by type */
+					HttpClientType clientType = HttpClientType.valueOf(System.getProperty(SYSTEM_HTTP_CLIENT_CREATE));
 					CloseableHttpAsyncClient client = HttpAsyncClients.createDefault();
+					if (HttpClientType.MINIMAL.equals(clientType)){
+						client = HttpAsyncClients.createMinimal();
+					} else if (HttpClientType.SYSTEM.equals(clientType)){
+						client = HttpAsyncClients.createSystem();
+					}else {
+						client = HttpAsyncClients.createDefault();
+					}
 					client.start();
 					httpAsyncClient = client;	    	   
 				}
@@ -19,15 +33,25 @@ public class HttpClientManager {
 		  
 		return httpAsyncClient;
 	}
-		
+
 	public static void setHttpAsyncClient(CloseableHttpAsyncClient httpAsyncClient) {
-		synchronized(HttpClientManager.class) {
-			if(HttpClientManager.httpAsyncClient == null) {
+		synchronized (HttpClientManager.class) {
+			if (HttpClientManager.httpAsyncClient == null) {
 				HttpClientManager.httpAsyncClient = httpAsyncClient;
-			}
-			else{
+			} else {
 				throw new RuntimeException("HttpAsyncClient was already set before or default one is being used.");
 			}
 		}
 	}
+
+	/**
+	 * Enum represent httpClients
+	 * 
+	 * @author manuel
+	 *
+	 */
+	public static enum HttpClientType {
+		DEFAULT, MINIMAL, SYSTEM;
+	}
+
 }

--- a/NotificationHubs/test/com/windowsazure/messaging/InstallationParseTest.java
+++ b/NotificationHubs/test/com/windowsazure/messaging/InstallationParseTest.java
@@ -8,6 +8,7 @@ import java.net.URISyntaxException;
 import java.text.ParseException;
 import java.text.SimpleDateFormat;
 import java.util.Date;
+import java.util.Locale;
 
 import org.apache.commons.io.IOUtils;
 import org.junit.Test;
@@ -31,7 +32,7 @@ public class InstallationParseTest {
 	
 	@Test
 	public void InstallationWnsFull() throws IOException, SAXException, URISyntaxException, ParseException {
-                SimpleDateFormat sdf = new SimpleDateFormat("EEE MMM dd HH:mm:ss z yyyy");
+        SimpleDateFormat sdf = new SimpleDateFormat("EEE MMM dd HH:mm:ss z yyyy", Locale.ENGLISH);
 		InputStream inputJson = this.getClass().getResourceAsStream("InstallationWnsFull");		
 		Installation installation = Installation.fromJson(inputJson);
 		assertNotNull(installation);


### PR DESCRIPTION
I have the same problem ... My work around is using environment var to select the strategy of httpclient creation .... 


To select strategy:

``
System.setProperty(HttpClientManager.SYSTEM_HTTP_CLIENT_CREATE,HttpClientManager.HttpClientType.SYSTEM.name());
``


	/** Name of system property to activate httpAsyncClient create with system properties */
	public static final String SYSTEM_HTTP_CLIENT_CREATE = "http_client_type";

	private static CloseableHttpAsyncClient httpAsyncClient;

	public static CloseableHttpAsyncClient getHttpAsyncClient() {
		if(httpAsyncClient == null) {
			synchronized(HttpClientManager.class) {
				if(httpAsyncClient == null) {
					/* Create http client by type */
					HttpClientType clientType = HttpClientType.valueOf(System.getProperty(SYSTEM_HTTP_CLIENT_CREATE));
					CloseableHttpAsyncClient client = HttpAsyncClients.createDefault();
					if (HttpClientType.MINIMAL.equals(clientType)){
						client = HttpAsyncClients.createMinimal();
					} else if (HttpClientType.SYSTEM.equals(clientType)){
						client = HttpAsyncClients.createSystem();
					}else {
						client = HttpAsyncClients.createDefault();
					}
					client.start();
					httpAsyncClient = client;	    	   
				}
			}
		}
		  
		return httpAsyncClient;
	}

	public static void setHttpAsyncClient(CloseableHttpAsyncClient httpAsyncClient) {
		synchronized (HttpClientManager.class) {
			if (HttpClientManager.httpAsyncClient == null) {
				HttpClientManager.httpAsyncClient = httpAsyncClient;
			} else {
				throw new RuntimeException("HttpAsyncClient was already set before or default one is being used.");
			}
		}
	}

	/**
	 * Enum represent httpClients
	 * 
	 * @author manuel
	 *
	 */
	public static enum HttpClientType {
		DEFAULT, MINIMAL, SYSTEM;
	}
``

