### PR TITLE
Capability to configure timeouts

### DIFF
--- a/NotificationHubs/pom.xml
+++ b/NotificationHubs/pom.xml
@@ -3,7 +3,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>com.windowsazure</groupId>
 	<artifactId>Notification-Hubs-java-sdk</artifactId>
-	<version>0.0.6</version>
+	<version>0.1.0</version>
 	<name>Windows Azure Notification Hubs - Java REST wrapper</name>
 	<build>
 		<sourceDirectory>src</sourceDirectory>

--- a/NotificationHubs/pom.xml
+++ b/NotificationHubs/pom.xml
@@ -3,7 +3,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>com.windowsazure</groupId>
 	<artifactId>Notification-Hubs-java-sdk</artifactId>
-	<version>0.0.5</version>
+	<version>0.0.6</version>
 	<name>Windows Azure Notification Hubs - Java REST wrapper</name>
 	<build>
 		<sourceDirectory>src</sourceDirectory>

--- a/NotificationHubs/src/com/windowsazure/messaging/HttpClientManager.java
+++ b/NotificationHubs/src/com/windowsazure/messaging/HttpClientManager.java
@@ -1,33 +1,66 @@
 package com.windowsazure.messaging;
 
 import org.apache.http.impl.nio.client.CloseableHttpAsyncClient;
-import org.apache.http.impl.nio.client.HttpAsyncClients;
+import org.apache.http.impl.nio.client.HttpAsyncClientBuilder;
+import org.apache.http.client.config.RequestConfig;
 
 public class HttpClientManager {
+
 	private static CloseableHttpAsyncClient httpAsyncClient;
-	
+
+	// A timeout value of zero is interpreted as an infinite timeout.
+	// A negative value is interpreted as undefined (system default).
+
+	// The timeout in milliseconds used when requesting a connection from the connection manager.
+	private static int ConnectionRequestTimeout = -1;
+
+	// The timeout in milliseconds until a connection is established.
+	private static int ConnectionTimeout = -1;
+
+	// The socket timeout in milliseconds, which is the timeout for waiting for data or,
+	// put differently, a maximum period inactivity between two consecutive data packets.
+	private static int SocketTimeout = -1;
+
 	public static CloseableHttpAsyncClient getHttpAsyncClient() {
-		if(httpAsyncClient == null) {
+		if (httpAsyncClient == null) {
 			synchronized(HttpClientManager.class) {
-				if(httpAsyncClient == null) {
-					CloseableHttpAsyncClient client = HttpAsyncClients.createDefault();
+				if (httpAsyncClient == null) {
+					RequestConfig config = RequestConfig.custom()
+														.setConnectionRequestTimeout(ConnectionRequestTimeout)
+														.setConnectTimeout(ConnectionTimeout)
+														.setSocketTimeout(SocketTimeout)
+														.build();
+					CloseableHttpAsyncClient client = HttpAsyncClientBuilder.create()
+																			.setDefaultRequestConfig(config)
+																			.build();
 					client.start();
-					httpAsyncClient = client;	    	   
+					httpAsyncClient = client;
 				}
 			}
 		}
-		  
 		return httpAsyncClient;
 	}
-		
+
 	public static void setHttpAsyncClient(CloseableHttpAsyncClient httpAsyncClient) {
 		synchronized(HttpClientManager.class) {
-			if(HttpClientManager.httpAsyncClient == null) {
+			if (HttpClientManager.httpAsyncClient == null) {
 				HttpClientManager.httpAsyncClient = httpAsyncClient;
 			}
-			else{
+			else {
 				throw new RuntimeException("HttpAsyncClient was already set before or default one is being used.");
 			}
 		}
+	}
+
+	public static void setConnectionRequestTimeout(int timeout) {
+		ConnectionRequestTimeout = timeout;
+	}
+
+	public static void setConnectTimeout(int timeout) {
+		ConnectionTimeout = timeout;
+	}
+
+	public static void setSocketTimeout(int timeout) {
+		SocketTimeout = timeout;
 	}
 }

--- a/NotificationHubs/src/com/windowsazure/messaging/HttpClientManager.java
+++ b/NotificationHubs/src/com/windowsazure/messaging/HttpClientManager.java
@@ -45,22 +45,33 @@ public class HttpClientManager {
         synchronized (HttpClientManager.class) {
             if (HttpClientManager.httpAsyncClient == null) {
                 HttpClientManager.httpAsyncClient = httpAsyncClient;
-            }
-            else {
+            } else {
                 throw new RuntimeException("HttpAsyncClient was already set before or default one is being used.");
             }
         }
     }
 
     public static void setConnectionRequestTimeout(int timeout) {
-        ConnectionRequestTimeout = timeout;
+        if (HttpClientManager.httpAsyncClient == null) {
+            ConnectionRequestTimeout = timeout;
+        } else {
+            throw new RuntimeException("Set timeout preference only before setting HttpAsyncClient or using default one.");
+        }
     }
 
     public static void setConnectTimeout(int timeout) {
-        ConnectionTimeout = timeout;
+        if (HttpClientManager.httpAsyncClient == null) {
+            ConnectionTimeout = timeout;
+        } else {
+            throw new RuntimeException("Set timeout preference only before setting HttpAsyncClient or using default one.");
+        }
     }
 
     public static void setSocketTimeout(int timeout) {
-        SocketTimeout = timeout;
+        if (HttpClientManager.httpAsyncClient == null) {
+            SocketTimeout = timeout;
+        } else {
+            throw new RuntimeException("Set timeout preference only before setting HttpAsyncClient or using default one.");
+        }
     }
 }

--- a/NotificationHubs/src/com/windowsazure/messaging/HttpClientManager.java
+++ b/NotificationHubs/src/com/windowsazure/messaging/HttpClientManager.java
@@ -22,7 +22,7 @@ public class HttpClientManager {
     // put differently, a maximum period inactivity between two consecutive data packets.
     private static int socketTimeout = -1;
 
-    public static CloseableHttpAsyncClient initializeHttpAsyncClient() {
+    private static void initializeHttpAsyncClient() {
         synchronized (HttpClientManager.class) {
             if (httpAsyncClient == null) {
                 RequestConfig config = RequestConfig.custom()
@@ -35,14 +35,14 @@ public class HttpClientManager {
                         .build();
                 client.start();
                 httpAsyncClient = client;
-            } else {
-                throw new RuntimeException("initializeHttpAsyncClient cannot be called twice or after setHttpAsyncClient.");
             }
         }
-        return httpAsyncClient;
     }
 
     public static CloseableHttpAsyncClient getHttpAsyncClient() {
+        if (httpAsyncClient == null) {
+            initializeHttpAsyncClient();
+        }
         return httpAsyncClient;
     }
 
@@ -51,7 +51,7 @@ public class HttpClientManager {
             if (HttpClientManager.httpAsyncClient == null) {
                 HttpClientManager.httpAsyncClient = httpAsyncClient;
             } else {
-                throw new RuntimeException("Cannot setHttpAsyncClient after having previously set, or after default already initialized.");
+                throw new RuntimeException("Cannot setHttpAsyncClient after having previously set, or after default already initialized from earlier call to getHttpAsyncClient.");
             }
         }
     }
@@ -61,7 +61,7 @@ public class HttpClientManager {
         if (HttpClientManager.httpAsyncClient == null) {
             connectionRequestTimeout = timeout;
         } else {
-            throw new RuntimeException("Set timeout preference only before initializeHttpAsyncClient.");
+            throw new RuntimeException("Cannot setConnectionRequestTimeout after previously setting httpAsyncClient, or after default already initialized from earlier call to getHttpAsyncClient.");
         }
     }
 
@@ -70,7 +70,7 @@ public class HttpClientManager {
         if (HttpClientManager.httpAsyncClient == null) {
             connectionTimeout = timeout;
         } else {
-            throw new RuntimeException("Set timeout preference only before initializeHttpAsyncClient.");
+            throw new RuntimeException("Cannot setConnectTimeout after previously setting httpAsyncClient, or after default already initialized from earlier call to getHttpAsyncClient.");
         }
     }
 
@@ -80,7 +80,7 @@ public class HttpClientManager {
         if (HttpClientManager.httpAsyncClient == null) {
             socketTimeout = timeout;
         } else {
-            throw new RuntimeException("Set timeout preference only before initializeHttpAsyncClient.");
+            throw new RuntimeException("Cannot setSocketTimeout after previously setting httpAsyncClient, or after default already initialized from earlier call to getHttpAsyncClient.");
         }
     }
 }

--- a/NotificationHubs/src/com/windowsazure/messaging/HttpClientManager.java
+++ b/NotificationHubs/src/com/windowsazure/messaging/HttpClientManager.java
@@ -6,61 +6,61 @@ import org.apache.http.client.config.RequestConfig;
 
 public class HttpClientManager {
 
-	private static CloseableHttpAsyncClient httpAsyncClient;
+    private static CloseableHttpAsyncClient httpAsyncClient;
 
-	// A timeout value of zero is interpreted as an infinite timeout.
-	// A negative value is interpreted as undefined (system default).
+    // A timeout value of zero is interpreted as an infinite timeout.
+    // A negative value is interpreted as undefined (system default).
 
-	// The timeout in milliseconds used when requesting a connection from the connection manager.
-	private static int ConnectionRequestTimeout = -1;
+    // The timeout in milliseconds used when requesting a connection from the connection manager.
+    private static int ConnectionRequestTimeout = -1;
 
-	// The timeout in milliseconds until a connection is established.
-	private static int ConnectionTimeout = -1;
+    // The timeout in milliseconds until a connection is established.
+    private static int ConnectionTimeout = -1;
 
-	// The socket timeout in milliseconds, which is the timeout for waiting for data or,
-	// put differently, a maximum period inactivity between two consecutive data packets.
-	private static int SocketTimeout = -1;
+    // The socket timeout in milliseconds, which is the timeout for waiting for data or,
+    // put differently, a maximum period inactivity between two consecutive data packets.
+    private static int SocketTimeout = -1;
 
-	public static CloseableHttpAsyncClient getHttpAsyncClient() {
-		if (httpAsyncClient == null) {
-			synchronized(HttpClientManager.class) {
-				if (httpAsyncClient == null) {
-					RequestConfig config = RequestConfig.custom()
-														.setConnectionRequestTimeout(ConnectionRequestTimeout)
-														.setConnectTimeout(ConnectionTimeout)
-														.setSocketTimeout(SocketTimeout)
-														.build();
-					CloseableHttpAsyncClient client = HttpAsyncClientBuilder.create()
-																			.setDefaultRequestConfig(config)
-																			.build();
-					client.start();
-					httpAsyncClient = client;
-				}
-			}
-		}
-		return httpAsyncClient;
-	}
+    public static CloseableHttpAsyncClient getHttpAsyncClient() {
+        if (httpAsyncClient == null) {
+            synchronized (HttpClientManager.class) {
+                if (httpAsyncClient == null) {
+                    RequestConfig config = RequestConfig.custom()
+                            .setConnectionRequestTimeout(ConnectionRequestTimeout)
+                            .setConnectTimeout(ConnectionTimeout)
+                            .setSocketTimeout(SocketTimeout)
+                            .build();
+                    CloseableHttpAsyncClient client = HttpAsyncClientBuilder.create()
+                            .setDefaultRequestConfig(config)
+                            .build();
+                    client.start();
+                    httpAsyncClient = client;
+                }
+            }
+        }
+        return httpAsyncClient;
+    }
 
-	public static void setHttpAsyncClient(CloseableHttpAsyncClient httpAsyncClient) {
-		synchronized(HttpClientManager.class) {
-			if (HttpClientManager.httpAsyncClient == null) {
-				HttpClientManager.httpAsyncClient = httpAsyncClient;
-			}
-			else {
-				throw new RuntimeException("HttpAsyncClient was already set before or default one is being used.");
-			}
-		}
-	}
+    public static void setHttpAsyncClient(CloseableHttpAsyncClient httpAsyncClient) {
+        synchronized (HttpClientManager.class) {
+            if (HttpClientManager.httpAsyncClient == null) {
+                HttpClientManager.httpAsyncClient = httpAsyncClient;
+            }
+            else {
+                throw new RuntimeException("HttpAsyncClient was already set before or default one is being used.");
+            }
+        }
+    }
 
-	public static void setConnectionRequestTimeout(int timeout) {
-		ConnectionRequestTimeout = timeout;
-	}
+    public static void setConnectionRequestTimeout(int timeout) {
+        ConnectionRequestTimeout = timeout;
+    }
 
-	public static void setConnectTimeout(int timeout) {
-		ConnectionTimeout = timeout;
-	}
+    public static void setConnectTimeout(int timeout) {
+        ConnectionTimeout = timeout;
+    }
 
-	public static void setSocketTimeout(int timeout) {
-		SocketTimeout = timeout;
-	}
+    public static void setSocketTimeout(int timeout) {
+        SocketTimeout = timeout;
+    }
 }


### PR DESCRIPTION
Before first using `HttpClientManager.getHttpAsyncClient()` there is capability to set operation timeouts.

The timeout in milliseconds used when requesting a connection from the connection manager.
`HttpClientManager.setConnectionRequestTimeout()`

The timeout in milliseconds until a connection is established.
`HttpClientManager.setConnectTimeout()`

The socket timeout in milliseconds, which is the timeout for waiting for data or,
put differently, a maximum period inactivity between two consecutive data packets.
`HttpClientManager.setSocketTimeout()`