### PR TITLE
Updating POM to use latest beanutils

### DIFF
--- a/NotificationHubs/pom.xml
+++ b/NotificationHubs/pom.xml
@@ -25,9 +25,56 @@
 					<target>1.7</target>
 				</configuration>
 			</plugin>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-enforcer-plugin</artifactId>
+				<version>3.0.0-M3</version>
+				<executions>
+					<execution>
+						<id>enforce-versions</id>
+						<goals>
+							<goal>enforce</goal>
+						</goals>
+						<configuration>
+						<rules>
+							<requireMavenVersion>
+							<version>3.6.3</version>
+							</requireMavenVersion>
+						</rules>
+						</configuration>
+					</execution>
+					
+					<execution>
+						<id>enforce</id>
+						<configuration>
+							<rules>
+								<dependencyConvergence/>
+							</rules>
+						</configuration>
+						<goals>
+							<goal>enforce</goal>
+						</goals>
+					</execution>
+				</executions>
+			</plugin>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-dependency-plugin</artifactId>
+				<executions>
+					<execution>
+					<id>analyze-dependencies</id>
+					<goals>
+						<goal>analyze-duplicate</goal>
+						<goal>analyze-only</goal>
+					</goals>
+					</execution>
+				</executions>
+				<configuration>
+					<failBuild>true</failBuild>
+				</configuration>
+			</plugin>
 		</plugins>
 	</build>
-
 	<dependencies>
 	    <dependency>
 			<groupId>junit</groupId>
@@ -41,14 +88,48 @@
 			<version>1.15</version>
 		</dependency>
 		<dependency>
+			<groupId>commons-logging</groupId>
+			<artifactId>commons-logging</artifactId>
+			<version>1.2</version>
+		</dependency>
+		<dependency>
 			<groupId>org.apache.commons</groupId>
 			<artifactId>commons-digester3</artifactId>
 			<version>3.2</version>
+			<exclusions>
+				<exclusion>
+					<groupId>commons-beanutils</groupId>
+					<artifactId>commons-beanutils</artifactId>
+				</exclusion>
+				<exclusion>
+					<groupId>commons-logging</groupId>
+					<artifactId>commons-logging</artifactId>
+				</exclusion>
+			</exclusions>
+		</dependency>
+		<dependency>
+			<groupId>commons-beanutils</groupId>
+			<artifactId>commons-beanutils</artifactId>
+			<version>1.9.4</version>
 		</dependency>
 		<dependency>
   		<groupId>org.apache.httpcomponents</groupId>
   			<artifactId>httpasyncclient</artifactId>
   			<version>4.1.4</version>
+			<exclusions>
+				<exclusion>
+					<groupId>commons-codec</groupId>
+					<artifactId>commons-codec</artifactId>
+				</exclusion>
+				<exclusion>
+					<groupId>org.apache.httpcomponents</groupId>
+					<artifactId>httpclient</artifactId>
+				</exclusion>
+				<exclusion>
+					<groupId>org.apache.httpcomponents</groupId>
+					<artifactId>httpcore</artifactId>
+				</exclusion>
+			</exclusions>
 		</dependency>
 		<dependency>
     		<groupId>org.apache.httpcomponents</groupId>
@@ -56,9 +137,20 @@
     		<version>4.5.12</version>
 		</dependency>
 		<dependency>
+			<groupId>org.apache.httpcomponents</groupId>
+			<artifactId>httpclient</artifactId>
+			<version>4.5.12</version>
+			<exclusions>
+				<exclusion>
+					<groupId>commons-codec</groupId>
+					<artifactId>commons-codec</artifactId>
+				</exclusion>
+			</exclusions>
+		</dependency>
+		<dependency>
     		<groupId>org.apache.httpcomponents</groupId>
     		<artifactId>httpcore</artifactId>
-    		<version>4.4.5</version>
+    		<version>4.4.13</version>
 		</dependency>
 		<dependency>
 			<groupId>commons-io</groupId>
@@ -68,12 +160,12 @@
 		<dependency>
     		<groupId>com.google.code.gson</groupId>
     		<artifactId>gson</artifactId>
-    		<version>2.3.1</version>
+    		<version>2.8.6</version>
 		</dependency>
 		<dependency>
 			<groupId>javax.xml.bind</groupId>
 			<artifactId>jaxb-api</artifactId>
-			<version>2.3.0</version>
+			<version>2.4.0-b180830.0359</version>
 		</dependency>
 	</dependencies>
 </project>


### PR DESCRIPTION
As per customer notice, there is an issue with the commons-digester3 with its requirement of commons-beanutils which had a [CVE](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2019-10086) that makes us upgrade from the internal 1.8.3 to 1.9.4.  This also adds maven updating and enforcement to the build.