### PR TITLE
Fixes 500 errors in Direct Batch Send, and upgrades httpclient to 5.2

### DIFF
--- a/NotificationHubs/pom.xml
+++ b/NotificationHubs/pom.xml
@@ -195,7 +195,7 @@
     <dependency>
       <groupId>org.apache.httpcomponents.client5</groupId>
       <artifactId>httpclient5</artifactId>
-      <version>5.1.3</version>
+      <version>5.2</version>
       <exclusions>
         <exclusion>
           <groupId>org.apache.httpcomponents.core5</groupId>
@@ -214,12 +214,12 @@
     <dependency>
       <groupId>org.apache.httpcomponents.core5</groupId>
       <artifactId>httpcore5</artifactId>
-      <version>5.2-beta2</version>
+      <version>5.2</version>
     </dependency>
     <dependency>
       <groupId>org.apache.httpcomponents.core5</groupId>
       <artifactId>httpcore5-h2</artifactId>
-      <version>5.2-beta2</version>
+      <version>5.2</version>
     </dependency>
     <dependency>
       <groupId>org.slf4j</groupId>

--- a/NotificationHubs/pom.xml
+++ b/NotificationHubs/pom.xml
@@ -156,12 +156,18 @@
     </plugins>
 	</build>
 	<dependencies>
-	    <dependency>
+    <dependency>
 			<groupId>junit</groupId>
 			<artifactId>junit</artifactId>
 			<version>4.13.2</version>
 			<scope>test</scope>
 		</dependency>
+    <dependency>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-core</artifactId>
+      <version>5.1.1</version>
+      <scope>test</scope>
+    </dependency>
 		<dependency>
 			<groupId>commons-codec</groupId>
 			<artifactId>commons-codec</artifactId>

--- a/NotificationHubs/src/com/windowsazure/messaging/HttpClientManager.java
+++ b/NotificationHubs/src/com/windowsazure/messaging/HttpClientManager.java
@@ -42,7 +42,7 @@ public class HttpClientManager {
                     .setConnectTimeout(Timeout.ofMilliseconds(connectionTimeout))
                     .build();
 
-                final CloseableHttpAsyncClient client = HttpAsyncClients.custom()
+                final CloseableHttpAsyncClient client = HttpAsyncClients.customHttp2()
                     .setIOReactorConfig(ioReactorConfig)
                     .setDefaultRequestConfig(config)
                     .setRetryStrategy(retryStrategy)

--- a/NotificationHubs/src/com/windowsazure/messaging/NotificationHub.java
+++ b/NotificationHubs/src/com/windowsazure/messaging/NotificationHub.java
@@ -12,10 +12,7 @@ import org.apache.hc.client5.http.entity.mime.FormBodyPartBuilder;
 import org.apache.hc.client5.http.entity.mime.MultipartEntityBuilder;
 import org.apache.hc.client5.http.entity.mime.StringBody;
 import org.apache.hc.core5.concurrent.FutureCallback;
-import org.apache.hc.core5.http.ContentType;
-import org.apache.hc.core5.http.Header;
-import org.apache.hc.core5.http.HttpEntity;
-import org.apache.hc.core5.http.Method;
+import org.apache.hc.core5.http.*;
 
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
@@ -987,6 +984,7 @@ public class NotificationHub extends NotificationHubsService implements Notifica
             .build();
 
         HttpEntity entity = MultipartEntityBuilder.create()
+            .setMimeSubtype("mixed")
             .setBoundary("nh-batch-multipart-boundary")
             .addPart(notificationPart)
             .addPart(devicesPart)
@@ -999,7 +997,7 @@ public class NotificationHub extends NotificationHubsService implements Notifica
             throw new RuntimeException(e);
         }
 
-        post.setBody(baoStream.toByteArray(), ContentType.MULTIPART_MIXED);
+        post.setBody(baoStream.toByteArray(), ContentType.parse(entity.getContentType()));
 
         executeRequest(post, callback, 201, response -> sendNotificationOutcome(callback, post, response));
     }

--- a/NotificationHubs/test/com/windowsazure/messaging/NotificationHubSendTest.java
+++ b/NotificationHubs/test/com/windowsazure/messaging/NotificationHubSendTest.java
@@ -1,2 +1,61 @@
-package com.windowsazure.messaging;public class NotificationHubSendTest {
+package com.windowsazure.messaging;
+
+import org.apache.hc.client5.http.async.methods.SimpleHttpRequest;
+import org.apache.hc.client5.http.async.methods.SimpleHttpResponse;
+import org.apache.hc.core5.concurrent.FutureCallback;
+import org.apache.hc.core5.http.ContentType;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Answers;
+import org.mockito.ArgumentCaptor;
+import org.mockito.ArgumentMatcher;
+import org.mockito.ArgumentMatchers;
+import org.mockito.invocation.InvocationOnMock;
+import org.mockito.stubbing.Answer;
+
+import java.net.URISyntaxException;
+import java.util.Arrays;
+import java.util.function.Consumer;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+public class NotificationHubSendTest {
+    private static final String CONNECTION_STRING = "Endpoint=sb://test-namespace.servicebus.windows.net/;SharedAccessKeyName=DefaultFullSharedAccessSignature;SharedAccessKey=JHadkDHkdhi74jaHdakhy/rZ6KEdfhasYdahO8JOx/1sZXTUlc=";
+    private static final String HUB_NAME = "test-hub";
+
+    private static final String GCMBODYTEMPLATE = "{\"aps\": {\"alert\": \"$(message)\"}}";
+
+    private NotificationHub hub;
+
+    @Before
+    public void setup() {
+        hub = spy(new NotificationHub(CONNECTION_STRING, HUB_NAME));
+        doAnswer(invocationOnMock -> {
+            Object[] args = invocationOnMock.getArguments();
+            Consumer<SimpleHttpResponse> consumer = (Consumer<SimpleHttpResponse>) args[3];
+            consumer.accept(mock(SimpleHttpResponse.class));
+            return invocationOnMock.getMock();
+        }).when(hub).executeRequest(any(), any(), any(), any());
+    }
+
+    @Test
+    public void testDirectBatchSend() throws NotificationHubsException, URISyntaxException {
+        Notification n = Notification.createFcmNotification(GCMBODYTEMPLATE);
+        NotificationOutcome o = hub.sendDirectNotification(n, Arrays.asList("Foo", "Bar"));
+
+        ArgumentCaptor<SimpleHttpRequest> requestCaptor = ArgumentCaptor.forClass(SimpleHttpRequest.class);
+        verify(hub).executeRequest(requestCaptor.capture(), any(), any(), any());
+
+        SimpleHttpRequest request = requestCaptor.getValue();
+        String uriPath = request.getUri().getPath();
+        String method = request.getMethod();
+        String boundary = request.getContentType().getParameter("boundary");
+
+        assertEquals("/" + HUB_NAME +"/messages/$batch", uriPath);
+        assertEquals("POST", method);
+        assertEquals("nh-batch-multipart-boundary", boundary);
+    }
 }


### PR DESCRIPTION
<!-- 
Thank you for submitting a pull request! Please add some info (if applicable) to give us some context on the PR.

We will review the PR as soon as possible, leave feedback, add a tag, etc. and let you know what's going on.

Thanks!

The Azure Notification Hubs team -->

Things to consider before you submit the PR:

* [Y] Are tests passing locally?
* [Y] Are the files formatted correctly?
* [-] Did you add unit tests?
* [Y] Did you test your change with either the sample apps that are included in the repository or with a blank app that uses your change?

## Description

This PR fixes the bug #150 in Direct Batch Send where the Content Type boundary was not being added on the request that's sent to ANH. 

This PR also upgrades the dependencies _httpclient_, and _httpcore_ to 5.2 to fix the issue #136 where we throw NoClassDefFoundError due to a mismatch in versions of our internal dependencies.

## Related PRs or issues

#150 
#136 

