### PR TITLE
Changes mockito version to 4.11.0 to be compatible with Java 8

### DIFF
--- a/NotificationHubs/pom.xml
+++ b/NotificationHubs/pom.xml
@@ -165,7 +165,13 @@
     <dependency>
       <groupId>org.mockito</groupId>
       <artifactId>mockito-core</artifactId>
-      <version>5.1.1</version>
+      <version>4.11.0</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-inline</artifactId>
+      <version>4.11.0</version>
       <scope>test</scope>
     </dependency>
 		<dependency>


### PR DESCRIPTION
Things to consider before you submit the PR:

* [Y] Are tests passing locally?
* [Y] Are the files formatted correctly?
* [-] Did you add unit tests?
* [Y] Did you test your change with either the sample apps that are included in the repository or with a blank app that uses your change?

## Description

The PR #160 added the Mockito package as a dependency, but that version (5.1.1) was incompatible with Java 8 which is what we use to build and release. 

This PR changes the version of Mockito to 4.11.0 which is compatible with Java 8.

## Related PRs or issues

#160
