### PR TITLE
#170 Follow-up PR: Updating docstring & using Junit4

### DIFF
--- a/NotificationHubs/src/com/windowsazure/messaging/GcmCredential.java
+++ b/NotificationHubs/src/com/windowsazure/messaging/GcmCredential.java
@@ -47,7 +47,7 @@ public final class GcmCredential extends PnsCredential {
      * Sets the Google Cloud Messaging API key.
      * @param googleApiKey The Google Cloud Messaging API key to set.
      *
-     * @deprecated use {@link #setGoogleApiKey(value) setGoogleApiKey} instead.
+     * @deprecated use {@link #setGoogleApiKey(String) setGoogleApiKey} instead.
      */
     @Deprecated
     public void setgoogleApiKey(String googleApiKey) {

--- a/NotificationHubs/src/com/windowsazure/messaging/GcmCredential.java
+++ b/NotificationHubs/src/com/windowsazure/messaging/GcmCredential.java
@@ -45,9 +45,9 @@ public final class GcmCredential extends PnsCredential {
 
     /**
      * Sets the Google Cloud Messaging API key.
-     * @param value The Google Cloud Messaging API key to set.
+     * @param googleApiKey The Google Cloud Messaging API key to set.
      *
-     * @deprecated use {@link #setGoogleApiKey()} instead.  
+     * @deprecated use {@link #setGoogleApiKey(value) setGoogleApiKey} instead.
      */
     @Deprecated
     public void setgoogleApiKey(String googleApiKey) {

--- a/NotificationHubs/src/com/windowsazure/messaging/PnsCredential.java
+++ b/NotificationHubs/src/com/windowsazure/messaging/PnsCredential.java
@@ -20,7 +20,7 @@ public abstract class PnsCredential {
     private static final String PROPERTIES_END = "</Properties>";
 
     public void setProperty(String propertyName, String propertyValue) throws Exception {
-    	var setterName = "set" + propertyName.substring(0, 1).toUpperCase() + propertyName.substring(1);
+    	String setterName = "set" + propertyName.substring(0, 1).toUpperCase() + propertyName.substring(1);
         this.getClass().getMethod(setterName, String.class).invoke(this, propertyValue);
     }
 

--- a/NotificationHubs/test/com/windowsazure/messaging/NotificationHubParseTest.java
+++ b/NotificationHubs/test/com/windowsazure/messaging/NotificationHubParseTest.java
@@ -6,8 +6,6 @@ package com.windowsazure.messaging;
 
 import org.apache.commons.io.IOUtils;
 import org.junit.Test;
-import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.ValueSource;
 import org.xml.sax.SAXException;
 
 import java.io.IOException;
@@ -20,11 +18,24 @@ import static org.junit.Assert.assertNotNull;
 
 public class NotificationHubParseTest {
 
-	@ParameterizedTest
-	@ValueSource(strings = {"NotificationHubDescriptionWithAllCredentials", "NotificationHubDescriptionWithAllCredentialsLowercaseNames"})
-    public void testParseNotificationHubWithAllCredentials(String inputFileName) throws IOException, SAXException {
+	@Test    
+	public void testParseNotificationHubWithAllCredentials() throws IOException, SAXException {
         InputStream inputXml = this.getClass()
-            .getResourceAsStream(inputFileName);
+            .getResourceAsStream("NotificationHubDescriptionWithAllCredentials");
+        NotificationHubDescription hub = NotificationHubDescription.parseOne(inputXml);
+        assertNotNull(hub);
+        assertEquals("test-hub", hub.getPath());
+
+        String expectedResultXml = IOUtils.toString(this.getClass()
+            .getResourceAsStream("NotificationHubDescriptionWithAllCredentialsNoSpaces"), StandardCharsets.UTF_8);
+        String actualResultXml = hub.getXml();
+        assertEquals(expectedResultXml, actualResultXml);
+    }
+	
+	@Test
+    public void testParseNotificationHubWithAllCredentialsLowercaseNames() throws IOException, SAXException {
+        InputStream inputXml = this.getClass()
+            .getResourceAsStream("NotificationHubDescriptionWithAllCredentialsLowercaseNames");
         NotificationHubDescription hub = NotificationHubDescription.parseOne(inputXml);
         assertNotNull(hub);
         assertEquals("test-hub", hub.getPath());


### PR DESCRIPTION
## Description
Followup PR for #170
- Fixes broken `@link` in docstring
- Reverts unit tests to use JUnit 4 (JUnit 5 upgrade requires separate PR due to namespace changes)
- Updates `var` to typed to match contention in repo

Things to consider before you submit the PR:
* [x] Are tests passing locally?
* [x] Are the files formatted correctly?
* [x] Did you add unit tests?
* [x] Did you test your change with either the sample apps that are included in the repository or with a blank app that uses your change?

## Related PRs or issues
#170

## Misc
Validated pipeline build succeeds
